### PR TITLE
Add a `socketstream_seqpacket` feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,23 @@
   </p>
 </div>
 
-This crate wraps [`socketpair`] with `AF_UNIX` and `SOCK_STREAM` on Posix-ish
-platforms, and emulates this interface using `CreateNamedPipe` on Windows.
+This crate wraps [`socketpair`] with `AF_UNIX` platforms, and emulates this
+interface using `CreateNamedPipe` on Windows.
+
+It has a "stream" interface, which corresponds to `SOCK_STREAM` and
+`PIPE_TYPE_BYTE`, and a "seqpacket" interface, which corresponds to
+`SOCK_SEQPACKET` and `PIPE_TYPE_MESSAGE`.
+
+## Example
+
+```rust
+let (mut a, mut b) = socketpair_stream()?;
+
+writeln!(a, "hello world")?;
+
+let mut buf = [0_u8; 4096];
+let n = b.read(&mut buf)?;
+assert_eq!(str::from_utf8(&buf[..n]).unwrap(), "hello world\n");
+```
 
 [`socketpair`]: https://man7.org/linux/man-pages/man2/socketpair.2.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,15 +44,15 @@ mod windows_async_std;
 mod windows_tokio;
 
 #[cfg(not(any(windows, unix)))]
-pub use crate::rustix::{socketpair_stream, SocketpairStream};
+pub use crate::rustix::{socketpair_seqpacket, socketpair_stream, SocketpairStream};
 #[cfg(unix)]
-pub use crate::unix::{socketpair_stream, SocketpairStream};
+pub use crate::unix::{socketpair_seqpacket, socketpair_stream, SocketpairStream};
 #[cfg(all(unix, feature = "async-std"))]
 pub use crate::unix_async_std::{async_std_socketpair_stream, AsyncStdSocketpairStream};
 #[cfg(all(unix, feature = "tokio"))]
 pub use crate::unix_tokio::{tokio_socketpair_stream, TokioSocketpairStream};
 #[cfg(windows)]
-pub use crate::windows::{socketpair_stream, SocketpairStream};
+pub use crate::windows::{socketpair_seqpacket, socketpair_stream, SocketpairStream};
 #[cfg(all(windows, feature = "async-std"))]
 pub use crate::windows_async_std::{async_std_socketpair_stream, AsyncStdSocketpairStream};
 #[cfg(all(windows, feature = "tokio"))]

--- a/src/rustix.rs
+++ b/src/rustix.rs
@@ -57,6 +57,27 @@ pub fn socketpair_stream() -> io::Result<(SocketpairStream, SocketpairStream)> {
     })?)
 }
 
+/// Create a socketpair and return seqpacket handles connected to each end.
+#[inline]
+pub fn socketpair_seqpacket() -> io::Result<(SocketpairStream, SocketpairStream)> {
+    Ok(rustix::net::socketpair(
+        AddressFamily::UNIX,
+        SocketType::SEQPACKET,
+        SocketFlags::CLOEXEC,
+        Protocol::default(),
+    )
+    .map(|(a, b)| {
+        let a = a.into_raw_fd();
+        let b = b.into_raw_fd();
+        unsafe {
+            (
+                SocketpairStream::from_raw_fd(a),
+                SocketpairStream::from_raw_fd(b),
+            )
+        }
+    })?)
+}
+
 impl Read for SocketpairStream {
     #[inline]
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {

--- a/src/rustix.rs
+++ b/src/rustix.rs
@@ -39,43 +39,35 @@ impl SocketpairStream {
 /// Create a socketpair and return stream handles connected to each end.
 #[inline]
 pub fn socketpair_stream() -> io::Result<(SocketpairStream, SocketpairStream)> {
-    Ok(rustix::net::socketpair(
+    let (a, b) = rustix::net::socketpair(
         AddressFamily::UNIX,
         SocketType::STREAM,
         SocketFlags::CLOEXEC,
         Protocol::default(),
-    )
-    .map(|(a, b)| {
-        let a = a.into_raw_fd();
-        let b = b.into_raw_fd();
-        unsafe {
-            (
-                SocketpairStream::from_raw_fd(a),
-                SocketpairStream::from_raw_fd(b),
-            )
-        }
-    })?)
+    )?;
+    unsafe {
+        Ok((
+            SocketpairStream::from_raw_fd(a.into_raw_fd()),
+            SocketpairStream::from_raw_fd(b.into_raw_fd()),
+        ))
+    }
 }
 
 /// Create a socketpair and return seqpacket handles connected to each end.
 #[inline]
 pub fn socketpair_seqpacket() -> io::Result<(SocketpairStream, SocketpairStream)> {
-    Ok(rustix::net::socketpair(
+    let (a, b) = rustix::net::socketpair(
         AddressFamily::UNIX,
         SocketType::SEQPACKET,
         SocketFlags::CLOEXEC,
         Protocol::default(),
-    )
-    .map(|(a, b)| {
-        let a = a.into_raw_fd();
-        let b = b.into_raw_fd();
-        unsafe {
-            (
-                SocketpairStream::from_raw_fd(a),
-                SocketpairStream::from_raw_fd(b),
-            )
-        }
-    })?)
+    )?;
+    unsafe {
+        Ok((
+            SocketpairStream::from_raw_fd(a.into_raw_fd()),
+            SocketpairStream::from_raw_fd(b.into_raw_fd()),
+        ))
+    }
 }
 
 impl Read for SocketpairStream {

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -4,6 +4,7 @@ use io_extras::os::rustix::{
     AsRawFd, AsRawReadWriteFd, AsReadWriteFd, FromRawFd, IntoRawFd, RawFd,
 };
 use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
+use rustix::net::{AddressFamily, Protocol, SocketFlags, SocketType};
 use std::fmt::{self, Arguments, Debug};
 use std::io::{self, IoSlice, IoSliceMut, Read, Write};
 use std::os::unix::net::UnixStream;
@@ -49,6 +50,27 @@ impl SocketpairStream {
 #[inline]
 pub fn socketpair_stream() -> io::Result<(SocketpairStream, SocketpairStream)> {
     UnixStream::pair().map(|(a, b)| (SocketpairStream(a), SocketpairStream(b)))
+}
+
+/// Create a socketpair and return seqpacket handles connected to each end.
+#[inline]
+pub fn socketpair_seqpacket() -> io::Result<(SocketpairStream, SocketpairStream)> {
+    Ok(rustix::net::socketpair(
+        AddressFamily::UNIX,
+        SocketType::SEQPACKET,
+        SocketFlags::CLOEXEC,
+        Protocol::default(),
+    )
+    .map(|(a, b)| {
+        let a = a.into_raw_fd();
+        let b = b.into_raw_fd();
+        unsafe {
+            (
+                SocketpairStream::from_raw_fd(a),
+                SocketpairStream::from_raw_fd(b),
+            )
+        }
+    })?)
 }
 
 impl Read for SocketpairStream {

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -55,22 +55,18 @@ pub fn socketpair_stream() -> io::Result<(SocketpairStream, SocketpairStream)> {
 /// Create a socketpair and return seqpacket handles connected to each end.
 #[inline]
 pub fn socketpair_seqpacket() -> io::Result<(SocketpairStream, SocketpairStream)> {
-    Ok(rustix::net::socketpair(
+    let (a, b) = rustix::net::socketpair(
         AddressFamily::UNIX,
         SocketType::SEQPACKET,
         SocketFlags::CLOEXEC,
         Protocol::default(),
-    )
-    .map(|(a, b)| {
-        let a = a.into_raw_fd();
-        let b = b.into_raw_fd();
-        unsafe {
-            (
-                SocketpairStream::from_raw_fd(a),
-                SocketpairStream::from_raw_fd(b),
-            )
-        }
-    })?)
+    )?;
+    unsafe {
+        Ok((
+            SocketpairStream::from_raw_fd(a.into_raw_fd()),
+            SocketpairStream::from_raw_fd(b.into_raw_fd()),
+        ))
+    }
 }
 
 impl Read for SocketpairStream {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -156,7 +156,7 @@ pub fn socketpair_seqpacket() -> io::Result<(SocketpairStream, SocketpairStream)
     Ok((first, second))
 }
 
-pub fn open_second_handle(path: Vec<u16>) -> io::Result<SocketpairStream> {
+fn open_second_handle(path: Vec<u16>) -> io::Result<SocketpairStream> {
     let second_raw_handle = unsafe {
         CreateFileW(
             path.as_ptr(),

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -23,8 +23,8 @@ use winapi::um::fileapi::{CreateFileW, OPEN_EXISTING};
 use winapi::um::handleapi::INVALID_HANDLE_VALUE;
 use winapi::um::namedpipeapi::{CreateNamedPipeW, PeekNamedPipe};
 use winapi::um::winbase::{
-    FILE_FLAG_FIRST_PIPE_INSTANCE, PIPE_ACCESS_DUPLEX, PIPE_READMODE_BYTE,
-    PIPE_REJECT_REMOTE_CLIENTS, PIPE_TYPE_BYTE, PIPE_UNLIMITED_INSTANCES,
+    FILE_FLAG_FIRST_PIPE_INSTANCE, PIPE_ACCESS_DUPLEX, PIPE_READMODE_BYTE, PIPE_READMODE_MESSAGE,
+    PIPE_REJECT_REMOTE_CLIENTS, PIPE_TYPE_BYTE, PIPE_TYPE_MESSAGE, PIPE_UNLIMITED_INSTANCES,
 };
 use winapi::um::winnt::{FILE_ATTRIBUTE_NORMAL, GENERIC_READ, GENERIC_WRITE};
 
@@ -115,6 +115,48 @@ pub fn socketpair_stream() -> io::Result<(SocketpairStream, SocketpairStream)> {
     };
     let first = unsafe { SocketpairStream::from_raw_handle(first_raw_handle) };
 
+    let second = open_second_handle(path)?;
+
+    Ok((first, second))
+}
+
+/// Create a socketpair and return seqpacket handles connected to each end.
+pub fn socketpair_seqpacket() -> io::Result<(SocketpairStream, SocketpairStream)> {
+    let (first_raw_handle, path) = loop {
+        let name = format!("\\\\.\\pipe\\{}", Uuid::new_v4());
+        let mut path = Path::new(&name)
+            .as_os_str()
+            .encode_wide()
+            .collect::<Vec<_>>();
+        path.push(0);
+        let first_raw_handle = unsafe {
+            CreateNamedPipeW(
+                path.as_ptr(),
+                PIPE_ACCESS_DUPLEX | FILE_FLAG_FIRST_PIPE_INSTANCE,
+                PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE | PIPE_REJECT_REMOTE_CLIENTS,
+                PIPE_UNLIMITED_INSTANCES,
+                4096,
+                4096,
+                0,
+                ptr::null_mut(),
+            )
+        };
+        if first_raw_handle != INVALID_HANDLE_VALUE {
+            break (first_raw_handle, path);
+        }
+        let err = io::Error::last_os_error();
+        if err.raw_os_error() != Some(ERROR_ACCESS_DENIED.try_into().unwrap()) {
+            return Err(err);
+        }
+    };
+    let first = unsafe { SocketpairStream::from_raw_handle(first_raw_handle) };
+
+    let second = open_second_handle(path)?;
+
+    Ok((first, second))
+}
+
+pub fn open_second_handle(path: Vec<u16>) -> io::Result<SocketpairStream> {
     let second_raw_handle = unsafe {
         CreateFileW(
             path.as_ptr(),
@@ -131,7 +173,7 @@ pub fn socketpair_stream() -> io::Result<(SocketpairStream, SocketpairStream)> {
     }
     let second = unsafe { SocketpairStream::from_raw_handle(second_raw_handle) };
 
-    Ok((first, second))
+    Ok(second)
 }
 
 impl Read for SocketpairStream {

--- a/tests/seqpacket.rs
+++ b/tests/seqpacket.rs
@@ -100,7 +100,10 @@ fn try_clone() -> anyhow::Result<()> {
     let mut buf = vec![0_u8; 6];
     b.read_exact(&mut buf)?;
     assert_eq!(str::from_utf8(&buf).unwrap(), "hello ");
-    assert_eq!(c.read_exact(&mut buf).unwrap_err().kind(), io::ErrorKind::UnexpectedEof);
+    assert_eq!(
+        c.read_exact(&mut buf).unwrap_err().kind(),
+        io::ErrorKind::UnexpectedEof
+    );
 
     Ok(())
 }
@@ -110,7 +113,10 @@ fn try_clone() -> anyhow::Result<()> {
 fn try_clone_two_writes() -> anyhow::Result<()> {
     let (mut a, mut b) = socketpair_seqpacket()?;
 
-    let _t = thread::spawn(move || -> io::Result<()> { write!(a, "hello ")?; writeln!(a, "world") });
+    let _t = thread::spawn(move || -> io::Result<()> {
+        write!(a, "hello ")?;
+        writeln!(a, "world")
+    });
 
     let mut c = b.try_clone()?;
 

--- a/tests/seqpacket.rs
+++ b/tests/seqpacket.rs
@@ -1,0 +1,124 @@
+use socketpair::socketpair_seqpacket;
+use std::io::{self, Read, Write};
+use std::sync::{Arc, Condvar, Mutex};
+use std::{str, thread};
+
+#[test]
+fn test() -> anyhow::Result<()> {
+    let (mut a, mut b) = socketpair_seqpacket()?;
+
+    let thread_a = thread::spawn(move || -> anyhow::Result<()> {
+        writeln!(a, "hello world")?;
+
+        let mut buf = [0_u8; 4096];
+        let n = a.read(&mut buf)?;
+        assert_eq!(str::from_utf8(&buf[..n]).unwrap(), "greetings\n");
+
+        writeln!(a, "goodbye")?;
+        Ok(())
+    });
+
+    let thread_b = thread::spawn(move || -> anyhow::Result<()> {
+        let mut buf = [0_u8; 4096];
+        let n = b.read(&mut buf)?;
+        assert_eq!(str::from_utf8(&buf[..n]).unwrap(), "hello world\n");
+
+        writeln!(b, "greetings")?;
+
+        let n = b.read(&mut buf)?;
+        assert_eq!(str::from_utf8(&buf[..n]).unwrap(), "goodbye\n");
+        Ok(())
+    });
+
+    thread_a.join().unwrap()?;
+    thread_b.join().unwrap()?;
+    Ok(())
+}
+
+#[test]
+fn one_way() -> anyhow::Result<()> {
+    let (mut a, mut b) = socketpair_seqpacket()?;
+
+    let _t = thread::spawn(move || -> io::Result<()> { writeln!(a, "hello world") });
+
+    let mut buf = String::new();
+    b.read_to_string(&mut buf)?;
+    assert_eq!(buf, "hello world\n");
+
+    Ok(())
+}
+
+#[test]
+fn peek() -> anyhow::Result<()> {
+    let pair = Arc::new((Mutex::new(false), Condvar::new()));
+    let pair_clone = Arc::clone(&pair);
+
+    let (mut a, mut b) = socketpair_seqpacket()?;
+
+    let _t = thread::spawn(move || -> io::Result<()> {
+        let (lock, cvar) = &*pair_clone;
+        let mut started = lock.lock().unwrap();
+
+        writeln!(a, "hello world")?;
+
+        *started = true;
+        drop(started);
+        cvar.notify_one();
+        Ok(())
+    });
+
+    let (lock, cvar) = &*pair;
+    let mut started = lock.lock().unwrap();
+    while !*started {
+        started = cvar.wait(started).unwrap();
+    }
+
+    assert_eq!(b.num_ready_bytes()?, 12);
+
+    let mut buf = vec![0_u8; 11];
+    assert_eq!(b.peek(&mut buf)?, 11);
+    assert_eq!(str::from_utf8(&buf).unwrap(), "hello world");
+
+    let mut buf = String::new();
+    b.read_to_string(&mut buf)?;
+    assert_eq!(buf, "hello world\n");
+
+    Ok(())
+}
+
+/// Like `try_clone` in the stream tests, but this doesn't work with seqpacket
+/// because one write is paired with two reads. We get an unexpected EOF trying to
+/// read to the end.
+#[test]
+fn try_clone() -> anyhow::Result<()> {
+    let (mut a, mut b) = socketpair_seqpacket()?;
+
+    let _t = thread::spawn(move || -> io::Result<()> { write!(a, "hello world") });
+
+    let mut c = b.try_clone()?;
+
+    let mut buf = vec![0_u8; 6];
+    b.read_exact(&mut buf)?;
+    assert_eq!(str::from_utf8(&buf).unwrap(), "hello ");
+    assert_eq!(c.read_exact(&mut buf).unwrap_err().kind(), io::ErrorKind::UnexpectedEof);
+
+    Ok(())
+}
+
+/// Like `try_clone` but use two writes so that it works with seqpacket.
+#[test]
+fn try_clone_two_writes() -> anyhow::Result<()> {
+    let (mut a, mut b) = socketpair_seqpacket()?;
+
+    let _t = thread::spawn(move || -> io::Result<()> { write!(a, "hello ")?; writeln!(a, "world") });
+
+    let mut c = b.try_clone()?;
+
+    let mut buf = vec![0_u8; 6];
+    b.read_exact(&mut buf)?;
+    assert_eq!(str::from_utf8(&buf).unwrap(), "hello ");
+    c.read_exact(&mut buf)?;
+    assert_eq!(str::from_utf8(&buf).unwrap(), "world\n");
+
+    Ok(())
+}


### PR DESCRIPTION
Add a `socketstream_seqpacket` feature, which uses `SOCK_SEQPACKET` on
Unix-type platforms and `PIPE_TYPE_MESSAGE` on Windows.