### PR TITLE
Disable seqpacket on macOS.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,13 +24,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [stable, windows]
+        build: [stable, windows, macos]
         include:
           - build: stable
             os: ubuntu-latest
             rust: stable
           - build: windows
             os: windows-latest
+            rust: stable
+          - build: macos
+            os: macos-latest
             rust: stable
 
     steps:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,8 +45,10 @@ mod windows_tokio;
 
 #[cfg(not(any(windows, unix)))]
 pub use crate::rustix::{socketpair_seqpacket, socketpair_stream, SocketpairStream};
+#[cfg(all(unix, not(any(target_os = "ios", target_os = "macos"))))]
+pub use crate::unix::socketpair_seqpacket;
 #[cfg(unix)]
-pub use crate::unix::{socketpair_seqpacket, socketpair_stream, SocketpairStream};
+pub use crate::unix::{socketpair_stream, SocketpairStream};
 #[cfg(all(unix, feature = "async-std"))]
 pub use crate::unix_async_std::{async_std_socketpair_stream, AsyncStdSocketpairStream};
 #[cfg(all(unix, feature = "tokio"))]

--- a/src/rustix.rs
+++ b/src/rustix.rs
@@ -54,6 +54,10 @@ pub fn socketpair_stream() -> io::Result<(SocketpairStream, SocketpairStream)> {
 }
 
 /// Create a socketpair and return seqpacket handles connected to each end.
+///
+/// Note that this is not available on macOS or ios due to missing OS support
+/// for `SOCK_SEQPACKET` with `AF_UNIX`.
+#[cfg(not(any(target_os = "ios", target_os = "macos")))]
 #[inline]
 pub fn socketpair_seqpacket() -> io::Result<(SocketpairStream, SocketpairStream)> {
     let (a, b) = rustix::net::socketpair(

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -4,6 +4,7 @@ use io_extras::os::rustix::{
     AsRawFd, AsRawReadWriteFd, AsReadWriteFd, FromRawFd, IntoRawFd, RawFd,
 };
 use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
+#[cfg(not(any(target_os = "ios", target_os = "macos")))]
 use rustix::net::{AddressFamily, Protocol, SocketFlags, SocketType};
 use std::fmt::{self, Arguments, Debug};
 use std::io::{self, IoSlice, IoSliceMut, Read, Write};
@@ -53,6 +54,10 @@ pub fn socketpair_stream() -> io::Result<(SocketpairStream, SocketpairStream)> {
 }
 
 /// Create a socketpair and return seqpacket handles connected to each end.
+///
+/// Note that this is not available on macOS or ios due to missing OS support
+/// for `SOCK_SEQPACKET` with `AF_UNIX`.
+#[cfg(not(any(target_os = "ios", target_os = "macos")))]
 #[inline]
 pub fn socketpair_seqpacket() -> io::Result<(SocketpairStream, SocketpairStream)> {
     let (a, b) = rustix::net::socketpair(

--- a/tests/seqpacket.rs
+++ b/tests/seqpacket.rs
@@ -1,3 +1,5 @@
+#![cfg(not(any(target_os = "ios", target_os = "macos")))]
+
 use socketpair::socketpair_seqpacket;
 use std::io::{self, Read, Write};
 use std::sync::{Arc, Condvar, Mutex};


### PR DESCRIPTION
macOS lacks `SOCK_SEQPACKET`  with `AF_UNIX`.