### PR TITLE
Implement `socketpair_seqpacket` for macOS.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,10 +41,8 @@ mod windows_async_std;
 #[cfg(all(windows, feature = "tokio"))]
 mod windows_tokio;
 
-#[cfg(all(unix, not(any(target_os = "ios", target_os = "macos"))))]
-pub use crate::rustix::socketpair_seqpacket;
 #[cfg(unix)]
-pub use crate::rustix::{socketpair_stream, SocketpairStream};
+pub use crate::rustix::{socketpair_seqpacket, socketpair_stream, SocketpairStream};
 #[cfg(all(unix, feature = "async-std"))]
 pub use crate::unix_async_std::{async_std_socketpair_stream, AsyncStdSocketpairStream};
 #[cfg(all(unix, feature = "tokio"))]

--- a/src/rustix.rs
+++ b/src/rustix.rs
@@ -78,9 +78,6 @@ pub fn socketpair_stream() -> io::Result<(SocketpairStream, SocketpairStream)> {
 }
 
 /// Create a socketpair and return seqpacket handles connected to each end.
-///
-/// Note that this is not available on macOS or ios due to missing OS support
-/// for `SOCK_SEQPACKET` with `AF_UNIX`.
 #[cfg(not(any(target_os = "ios", target_os = "macos")))]
 #[inline]
 pub fn socketpair_seqpacket() -> io::Result<(SocketpairStream, SocketpairStream)> {
@@ -90,6 +87,31 @@ pub fn socketpair_seqpacket() -> io::Result<(SocketpairStream, SocketpairStream)
         SocketFlags::CLOEXEC,
         Protocol::default(),
     )?;
+    Ok((
+        SocketpairStream::from_fd(a.into()),
+        SocketpairStream::from_fd(b.into()),
+    ))
+}
+
+/// Create a socketpair and return seqpacket handles connected to each end.
+#[cfg(any(target_os = "ios", target_os = "macos"))]
+#[inline]
+pub fn socketpair_seqpacket() -> io::Result<(SocketpairStream, SocketpairStream)> {
+    // Darwin doesn't support `SEQPACKET` on `UNIX`-domain sockets, so we use
+    // `DGRAM` instead, which also provides packet-boundary semantics. `DGRAM`
+    // isn't reliable in general, but is commonly understood to be reliable
+    // in the `UNIX` domain.
+    //
+    // And, Darwin doesn't have `SOCK_CLOEXEC`. So we call `ioctl_fioclex`
+    // to emulate it.
+    let (a, b) = rustix::net::socketpair(
+        AddressFamily::UNIX,
+        SocketType::DGRAM,
+        SocketFlags::empty(),
+        Protocol::default(),
+    )?;
+    rustix::io::ioctl_fioclex(&a)?;
+    rustix::io::ioctl_fioclex(&b)?;
     Ok((
         SocketpairStream::from_fd(a.into()),
         SocketpairStream::from_fd(b.into()),

--- a/tests/seqpacket.rs
+++ b/tests/seqpacket.rs
@@ -167,11 +167,14 @@ fn test_reliable() -> anyhow::Result<()> {
         for _ in 0..0x10000 {
             let n = c.read(&mut buf)?;
             let s = str::from_utf8(&buf[..n]).unwrap();
+            dbg!(s);
             if let Some(x) = s.strip_prefix("thread A: ") {
+                dbg!(x);
                 let new_a = u32::from_str(x).unwrap();
                 assert_eq!(new_a, expect_a);
                 expect_a = new_a + 1;
             } else if let Some(x) = s.strip_prefix("thread B: ") {
+                dbg!(x);
                 let new_b = u32::from_str(x).unwrap();
                 assert_eq!(new_b, expect_b);
                 expect_b = new_b + 1;

--- a/tests/seqpacket.rs
+++ b/tests/seqpacket.rs
@@ -182,8 +182,8 @@ fn test_reliable() -> anyhow::Result<()> {
         Ok(())
     });
 
+    thread_c.join().unwrap()?;
     thread_a.join().unwrap()?;
     thread_b.join().unwrap()?;
-    thread_c.join().unwrap()?;
     Ok(())
 }

--- a/tests/seqpacket.rs
+++ b/tests/seqpacket.rs
@@ -2,6 +2,7 @@
 
 use socketpair::socketpair_seqpacket;
 use std::io::{self, Read, Write};
+use std::str::FromStr;
 use std::sync::{Arc, Condvar, Mutex};
 use std::{str, thread};
 
@@ -89,8 +90,8 @@ fn peek() -> anyhow::Result<()> {
 }
 
 /// Like `try_clone` in the stream tests, but this doesn't work with seqpacket
-/// because one write is paired with two reads. We get an unexpected EOF trying to
-/// read to the end.
+/// because one write is paired with two reads. We get an unexpected EOF trying
+/// to read to the end.
 #[test]
 fn try_clone() -> anyhow::Result<()> {
     let (mut a, mut b) = socketpair_seqpacket()?;
@@ -128,5 +129,61 @@ fn try_clone_two_writes() -> anyhow::Result<()> {
     c.read_exact(&mut buf)?;
     assert_eq!(str::from_utf8(&buf).unwrap(), "world\n");
 
+    Ok(())
+}
+
+/// `socketpair_seqpacket` should be reliable. Do a simple test to catch
+/// obvious unreliability.
+#[test]
+fn test_reliable() -> anyhow::Result<()> {
+    let (mut a, mut c) = socketpair_seqpacket()?;
+    let mut b = a.try_clone()?;
+
+    // Write a bunch of messages from multiple threads, to see if they'll
+    // interfere with each other.
+    let thread_a = thread::spawn(move || -> anyhow::Result<()> {
+        for i in 0..0x8000 {
+            write!(a, "{}", format!("thread A: {}", i))?;
+        }
+        Ok(())
+    });
+    let thread_b = thread::spawn(move || -> anyhow::Result<()> {
+        for i in 0..0x8000 {
+            write!(b, "{}", format!("thread B: {}", i))?;
+        }
+        Ok(())
+    });
+
+    // Give the threads some time to fill up the socket buffers, to see
+    // if they'll start dropping packets.
+    std::thread::sleep(std::time::Duration::from_secs(5));
+
+    // Read the packets, and assert they arrive in the right order.
+    let thread_c = thread::spawn(move || -> anyhow::Result<()> {
+        let mut buf = [0_u8; 4096];
+
+        let mut expect_a = 0;
+        let mut expect_b = 0;
+        for _ in 0..0x10000 {
+            let n = c.read(&mut buf)?;
+            let s = str::from_utf8(&buf[..n]).unwrap();
+            if let Some(x) = s.strip_prefix("thread A: ") {
+                let new_a = u32::from_str(x).unwrap();
+                assert_eq!(new_a, expect_a);
+                expect_a = new_a + 1;
+            } else if let Some(x) = s.strip_prefix("thread B: ") {
+                let new_b = u32::from_str(x).unwrap();
+                assert_eq!(new_b, expect_b);
+                expect_b = new_b + 1;
+            } else {
+                unreachable!("unexpected message");
+            }
+        }
+        Ok(())
+    });
+
+    thread_a.join().unwrap()?;
+    thread_b.join().unwrap()?;
+    thread_c.join().unwrap()?;
     Ok(())
 }


### PR DESCRIPTION
macOS doesn't support `SOCK_SEQPACKET` on `AF_UNIX` sockets, but it does
support `SOCK_DGRAM` on `AF_UNIX` sockets, which has packet-boundary
semantics, and which is believed to be reliable in `AF_UNIX` sockets.